### PR TITLE
Set long connection timeout

### DIFF
--- a/templates/10-k8s-master.conf.j2
+++ b/templates/10-k8s-master.conf.j2
@@ -10,10 +10,12 @@ frontend HTTPS-intern
     mode tcp
     bind {{ kubernetes_ha_ip_intern }}:443
     mode     tcp
+    timeout client 180d
     default_backend kube-apiserver
 
 backend kube-apiserver
     mode      tcp
+    timeout server 180d
     balance source
     hash-type consistent
     option httpchk GET /healthz HTTP/1.1\r\nHost:\ {{ kubernetes_ha_domain_intern }}


### PR DESCRIPTION
When k8router wants to watch ingress changes there are long periods
without activity. If haproxy terminates these connections no events will
be watched by k8router. So this has to be very long.

https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20client
https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-timeout%20server